### PR TITLE
Revert "Mark concerts as 'temporarily disabled'..."

### DIFF
--- a/app/views/apis/concerts.jade
+++ b/app/views/apis/concerts.jade
@@ -6,12 +6,11 @@ article.article.dark.endpoint
       h4 Source: <a href="http://midi.is/atburdir/?c=1&p=1" target="_blank">midi.is</a>
 
     .box.light.api
-      .content.title
+      .content.title.blue
         .method get
-        .path /concerts
+        .path: a(href="http://apis.is/concerts", target="_blank") /concerts
 
       .content
-        p.warning <b>Note</b>, this endpoint has been temporarily disabled! Check out <a href="https://github.com/kristjanmik/apis/issues/90">the issue</a> for more information
         p Get a list of all the concerts in Iceland sorted by date
 
         h5.leading.collapse-next curl demo

--- a/public/css/elements/box.less
+++ b/public/css/elements/box.less
@@ -43,10 +43,6 @@
   &.api {
 
     .content {
-    
-      .warning {
-        color: red;
-      }
 
       &.title {
         .clearfix();


### PR DESCRIPTION
This reverts commit 447cfc95f8a50fe1fa8c70809fd866214dd623bd.

Since kristjanmik/apis#130 is merged it makes sense to re-enable the endpoint in the docs.
